### PR TITLE
add license information to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,5 +19,6 @@
     },
     "devDependencies": {
         "angular-mocks": ">=1.2.0"
-    }
+    },
+	"license": "ISC"
 }


### PR DESCRIPTION
To add a new release of AngularStompDK to http://www.webjars.org/bower it is required to add license information into the bower.json file. 

The missing license definition prevents deployments of new releases:

> Failed! All attempts to determine a license have been exhausted. The bower.json did not contain a spec-compliant license definition and the license could not be determined by trolling through the GitHub repo. This problem will likely need to be resolved by working with the library maintainers directly. If you feel you have reached this failure in error, please file an issue: https://github.com/webjars/webjars/issues  Determined Artifact Name: AngularStompDK Starting Deploy